### PR TITLE
fix(gitignore): fixed path backslash to slash on windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,65 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Main
+
+on:
+  push:
+    branches: [master]
+    tags:
+      - v*
+  pull_request:
+    branches: [master]
+
+env:
+  NODE_VERSION: 12.x
+  ORGANIZATION_KEY: template
+
+jobs:
+  testBuildAndRelease:
+    name: 'Test, build and release'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://npm.pkg.github.com
+          always-auth: 'true'
+
+      - name: Install dependencies
+        run: yarn
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
+
+      # - name: Lint
+      #   run: yarn lint
+
+      # - name: Test
+      #   run: yarn test
+      #   env:
+      #     CI: 'true'
+
+      - name: Build
+        run: yarn build
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
+
+      - name: Publish package
+        if: contains(github.ref, 'refs/tags/v')
+        run: yarn publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
+
+      - name: Slack Notification
+        if: always()
+        run: |
+          yarn global add @bbitgmbh/bbit.slack
+          $(yarn global bin)/bslack gha --status ${{ job.status }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BBIT_BOT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Build your packages only if they changed since the last build.
 1. Install the package:
 
 ```sh
-yarn add build-if-changed -D
+yarn add @bbitgmbh/build-if-changed -D
 ```
 
 2. Edit your `package.json` module to customize the behavior:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbitgmbh/build-if-changed",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "Run build scripts only when files changed",
   "license": "MIT",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "build-if-changed",
+  "name": "@bbitgmbh/build-if-changed",
   "version": "1.5.5",
   "description": "Run build scripts only when files changed",
   "license": "MIT",
@@ -14,8 +14,7 @@
     "help.txt"
   ],
   "scripts": {
-    "build": "tsc -p .",
-    "prepublishOnly": "yarn build"
+    "build": "tsc -p ."
   },
   "dependencies": {
     "ansi-256-colors": "^1.1.0",
@@ -35,16 +34,17 @@
     "pretty-quick": "^1.11.0",
     "typescript": "^3.5.1"
   },
-  "author": "Alec Larson",
+  "author": "Roger Jaggi",
   "contributors": [
-    "Michel Weststrate"
+    "Michel Weststrate",
+    "Alec Larson"
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/aleclarson/build-if-changed.git"
+    "url": "git+https://github.com/bbitgmbh/build-if-changed.git"
   },
-  "homepage": "https://github.com/aleclarson/build-if-changed#readme",
+  "homepage": "https://github.com/bbitgmbh/build-if-changed#readme",
   "bugs": {
-    "url": "https://github.com/aleclarson/build-if-changed/issues"
+    "url": "https://github.com/bbitgmbh/build-if-changed/issues"
   }
 }

--- a/src/gitignore.ts
+++ b/src/gitignore.ts
@@ -41,7 +41,9 @@ export class GitIgnore {
           }
         } else if (fs.isFile(path)) {
           const lines = readLines(path).filter(line => line && line[0] !== '#')
-          match = createMatcher(lines, glob => join(dir, glob))
+          match = createMatcher(lines, glob =>
+            join(dir, glob).replace(/\\/g, '/')
+          )
           this.globTree[pathId] = match || false
           if (match && match(file, name)) {
             return true


### PR DESCRIPTION
path.join creates paths with backslashes on windows, but the glob-modules regexes just support forward slashes. This fix replaces any backslash with slashes so that it should work on all OSs.